### PR TITLE
Build a base image to experiment with

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:jessie
+
+ENV docker_version=1.11.2-0~jessie
+ENV compose_version=1.8.0
+
+RUN apt-get update \
+  && apt-get install -y apt-transport-https curl ca-certificates \
+  && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
+  && echo "deb https://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y docker-engine=$docker_version \
+  && rm -r /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/docker/compose/releases/download/$compose_version/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose \
+  && chmod +x /usr/local/bin/docker-compose
+
+# This image expects a mounted docker.sock or env that points to docker tcp
+RUN update-rc.d -f docker remove
+
+VOLUME /source
+WORKDIR /source
+
+ENTRYPOINT build-contract
+ADD build-contract /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # build-contract
-Defines a successful build and test run for a microservice, from git clone to docker push
+Defines a successful build and test run for a microservice, from source to docker push
+
+## using locally
+
+Invoke build-contract in current folder, use host's docker:
+```
+docker build --tag yolean/build-contract .
+docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/:/source yolean/build-contract
+```

--- a/build-contract
+++ b/build-contract
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "In $(pwd) at $(date -Iseconds) on $(hostname)"
+
+[ -f Dockerfile ] || {
+  echo "This can't be a build-contract compatible project, can it? There's no Dockerfile."
+  exit 1
+}
+
+ls -l
+echo "The actual contract is still to be defined"
+sleep 10


### PR DESCRIPTION
The alternative to a mounted source volume is to have an argument or env that points to a tarball download that can be curl'd. Or a zip download like in https://github.com/solsson/dockerfiles/blob/master/node/run-zip.