### PR TITLE
Force pull at build when run with push goal

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -38,12 +38,17 @@ function wait_for_contract {
 }
 
 # Perform tests
+BUILD_FLAGS='--build --force-recreate';
+if [[ $DO_PUSH == true ]]; then
+  BUILD_FLAGS="$BUILD_FLAGS --pull";
+fi
+
 cd $ROOT/build-contracts/
 for compose_file in $(ls | grep .yml); do
   echo "  --- build-contract: $compose_file ---  "
   docker_compose="docker-compose -f $compose_file"
   $docker_compose rm -f
-  $docker_compose up --build --force-recreate -d
+  $docker_compose up $BUILD_FLAGS -d
   $docker_compose logs -f &
   bar=$(wait_for_contract)
   echo "Build Contract finished with $bar"


### PR DESCRIPTION
We found no other way to reliably get upstream builds on a build server. https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375

Updating to `@sha256:` for every new upstream build would lead to a lot of nonsense commits.

We still recommend always running with sha references in production, where you're otherwise affected by the docker run history on particular nodes.