### PR TITLE
Set git info variable(s) like Jenkins does

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -20,7 +20,7 @@ if [[ ! -z "$GIT_COMMIT" ]]; then
   if [[ ! -z "$GIT_STATUS" ]]; then
     GIT_COMMIT="$GIT_COMMIT-dev"
   fi
-  echo "This is a git repo and GIT_COMMIT=$GIT_COMMIT"
+  echo "  --- build-contract: This is a git repo and GIT_COMMIT=$GIT_COMMIT ---  "
   export GIT_COMMIT
 fi
 

--- a/build-contract
+++ b/build-contract
@@ -14,6 +14,15 @@ else
   echo "  --- build-contract: Offline run (builds will not docker pull and image: will not be pushed) ---  "
 fi
 
+GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null)
+if [[ ! -z "$GIT_COMMIT" ]]; then
+  GIT_STATUS=$(git status -s)
+  if [[ ! -z "$GIT_STATUS" ]]; then
+    GIT_COMMIT="$GIT_COMMIT-dev"
+  fi
+  echo "This is a git repo and GIT_COMMIT=$GIT_COMMIT"
+  export GIT_COMMIT
+fi
 
 # echo "In $(pwd) at $(date -Iseconds) on $(hostname)"
 


### PR DESCRIPTION
See Environment Variables in https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin. I figure this is good for tagging, or at least we should always [label](https://docs.docker.com/engine/userguide/labels-custom-metadata/) our images with it. Starting with GIT_COMMIT, but because we unlike jenkins tend to run the same job locally I'm adding a suffix `-dev` if the clone is unclean.