### PR TITLE
Don't require PUSH_TAG

### DIFF
--- a/parsetargets
+++ b/parsetargets
@@ -19,7 +19,7 @@ for (let key in services) {
     (Array.isArray(labels) && labels.indexOf(TARGET_LABEL) !== -1)) {
 
     if (!VALID_PUSH_RE.test(service.image))
-      throw new Error(`${service.image} is not a valid image name!`);
+      throw new Error('Not a valid image name: ' + service.image);
 
     console.log(key);
   }

--- a/parsetargets
+++ b/parsetargets
@@ -5,7 +5,7 @@ const fs = require('fs');
 const TARGET_LABEL = 'com.yolean.build-target';
 
 // Let's not push anything where we don't want it!
-const VALID_PUSH_RE = /((^localhost\:5000)|(^\$REGISTRY_HOST)).*(\:\$PUSH_TAG$)/;
+const VALID_PUSH_RE = /((^localhost\:5000)|(^\$REGISTRY_HOST)).*\:(\$[A-Z_]+|[0-9a-z\.-]+)$/;
 // Matches two different approaches:
 // $REGISTRY_HOST/group/name:$PUSH_TAG
 // localhost:5000/group/name:$PUSH_TAG


### PR DESCRIPTION
Tagging strategy can be entirely up to local versioning and build strategies. The problem with local depent builds must be solved using hard coded tag names in downstream dockerfiles anyway.