### PR TITLE
Pick up BUILD_FLAGS from external env

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -51,7 +51,7 @@ function wait_for_contract {
 }
 
 # Perform tests
-BUILD_FLAGS='';
+BUILD_FLAGS="$BUILD_FLAGS";
 if [[ $DO_PUSH == true ]]; then
   BUILD_FLAGS="$BUILD_FLAGS --pull";
 fi


### PR DESCRIPTION
and append internally deduced, such as `--pull`.

This lets us disable docker build caching, for example due to RUN steps that have time dependent results. Not core, according to https://github.com/docker/docker/issues/1996.