### PR TITLE
Add BUILD_TIMESTAMP env var

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -16,7 +16,7 @@ fi
 
 [[ -z "$PROJECT_NAME" ]] && PROJECT_NAME=${ROOT##*/}
 
-export DATE_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null)
 if [[ ! -z "$GIT_COMMIT" ]]; then

--- a/build-contract
+++ b/build-contract
@@ -16,6 +16,8 @@ fi
 
 [[ -z "$PROJECT_NAME" ]] && PROJECT_NAME=${ROOT##*/}
 
+export DATE_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
 GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null)
 if [[ ! -z "$GIT_COMMIT" ]]; then
   GIT_STATUS=$(git status -s)


### PR DESCRIPTION
As an alternative to #22. Jenkins has https://issues.jenkins-ci.org/browse/JENKINS-26520.

To use this to disable caching of a run step (inspired by http://stackoverflow.com/questions/36996046/how-to-prevent-dockerfile-caching-git-clone):

In a build contract compose yml:
```yaml
services:
  x:
    build:
      context: ../
      args:
        timestamp: ${BUILD_TIMESTAMP}
```

and dockerfile 
```
RUN BUILD_TIMESTAMP=${timestamp} \
  && my-stuff-that-should-not-be-cached
```
