### PR TITLE
On build-contract failure, output docker-compose ps to help developer…

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -79,6 +79,7 @@ for compose_file in $(ls $CONTRACTS_DIR | grep .yml); do
   if [[ $bar -ne 0 ]]; then
     echo "ERROR: Build Contract $compose_file failed, please see logs above for details"
     echo "ERROR: Aborting build!"
+    $docker_compose ps
     exit $bar
   fi
 done


### PR DESCRIPTION
… understand what went wrong.

A build-contract with a couple of containers produce a lot of logs. Summarizing what went wrong makes it easier to locate which (test-)container crashed.