### PR TITLE
For some reason, container names now seem to allow _ and - characters…

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -32,7 +32,7 @@ fi
 
 function wait_for_contract {
   sleep 3
-  compose_name=$(echo "$1" | sed 's/[^A-Za-z0-9]//g')
+  compose_name=$(echo "$1" | sed 's/[^A-Za-z0-9_-]//g')
   # Count the number of failed containers
   # NOTE: Assumes no other build contract process is running at the same time
   filters="-f label=com.yolean.build-contract -f name=$compose_name"


### PR DESCRIPTION
… in them, which totally broke this script