### PR TITLE
Try to produce consistent monorepo tgz hashes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!build-contract
+!package.json
+!parsetargets
+!nodejs

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,12 @@ RUN curl -L https://github.com/docker/compose/releases/download/$compose_version
 VOLUME /source
 WORKDIR /source
 
-COPY package.json build-contract parsetargets /usr/src/app/
+COPY package.json /usr/src/app/
+RUN cd /usr/src/app/ && npm install --production
+COPY build-contract parsetargets /usr/src/app/
 COPY nodejs /usr/src/app/nodejs
-RUN cd /usr/src/app/ && npm install --production && npm link
+# This step seems to do an extra npm install, possibly with dev deps
+RUN cd /usr/src/app/ && npm link
+
 ENTRYPOINT ["build-contract"]
 CMD ["push"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yolean/node@sha256:f033123ae2292d60769e5b8eff94c4b7b9d299648d0d23917319c0743029c5ef
+FROM yolean/node@sha256:e591eac6f5d1f07876bd63bba2bbd1c1218521c5ed5312692851597b47089775
 
 ENV docker_version=17.09.1~ce-0~debian
 ENV compose_version=1.21.0 compose_sha256=af639f5e9ca229442c8738135b5015450d56e2c1ae07c0aaa93b7da9fe09c2b0

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ WORKDIR /source
 
 COPY package.json build-contract parsetargets /usr/src/app/
 COPY nodejs /usr/src/app/nodejs
-RUN cd /usr/src/app/ && npm install && npm link
+RUN cd /usr/src/app/ && npm install --production && npm link
 ENTRYPOINT ["build-contract"]
 CMD ["push"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ COPY package.json /usr/src/app/
 RUN cd /usr/src/app/ && npm install --production
 COPY build-contract parsetargets /usr/src/app/
 COPY nodejs /usr/src/app/nodejs
-# This step seems to do an extra npm install, possibly with dev deps
-RUN cd /usr/src/app/ && npm link
+RUN cd /usr/src/app/ && npm link --only=production
 
 ENTRYPOINT ["build-contract"]
 CMD ["push"]

--- a/build-contract
+++ b/build-contract
@@ -32,7 +32,7 @@ fi
 
 function wait_for_contract {
   sleep 3
-  compose_name=$(echo "$1" | sed 's/[^A-Za-z0-9]//g')
+  compose_name=$(echo "$1" | sed 's/[^A-Za-z0-9_-]//g')
   # Count the number of failed containers
   # NOTE: Assumes no other build contract process is running at the same time
   filters="-f label=com.yolean.build-contract -f name=$compose_name"

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -1,12 +1,25 @@
 version: "2"
 services:
+  build-contract:
+    image: yolean/build-contract
+    build:
+      context: ../
+    labels:
+    - com.yolean.build-target
+
+  unittest:
+    build:
+      context: ../
+      dockerfile: ./build-contracts/unittest/Dockerfile
+    labels:
+    - com.yolean.build-contract
+
   nginx:
     image: nginx
+
   client:
     build: ./client
-    image: localhost:5000/build-contract-test/client:$PUSH_TAG
     environment:
       TEST_EXIT_CODE: $TEST_EXIT_CODE
     labels:
-      com.yolean.build-contract: ""
-      com.yolean.build-target: ""
+    - com.yolean.build-contract

--- a/build-contracts/unittest/Dockerfile
+++ b/build-contracts/unittest/Dockerfile
@@ -1,0 +1,11 @@
+FROM yolean/node@sha256:e591eac6f5d1f07876bd63bba2bbd1c1218521c5ed5312692851597b47089775
+
+WORKDIR /usr/src/app
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+RUN npm run unittest

--- a/nodejs/build-contract-packagelock
+++ b/nodejs/build-contract-packagelock
@@ -6,5 +6,10 @@ $SCRIPTPATH/build-contract-predockerbuild
 
 cd npm-monorepo/ci
 npm install --production --package-lock-only --ignore-scripts
+echo "------- packagelock details -------"
+cat ../../npm-monorepo/ci/package.json
+echo ""
+shasum -a 256 ../../npm-monorepo/ci/npm-monorepo/*
+echo "------- packagelock details -------"
 mv package-lock.json ../../
 cd ../../

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -109,6 +109,12 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
           process.chdir(cimdir); // for npm
           npmPackage(cimdir, (err, tgzname) => {
             console.log('# Created monorepo sourceless tarball for npm ci', cimdir, tgzname);
+            console.log('------- debug info -------');
+            require('child_process').execSync('tar xvzf ' + tgzname, {stdio:[0,1,2]});
+            require('child_process').execSync('ls -la package/', {stdio:[0,1,2]});
+            require('child_process').execSync('shasum package/package.json', {stdio:[0,1,2]});
+            require('child_process').execSync('rm -rf package/', {stdio:[0,1,2]});
+            console.log('------- ---------- -------');
             next(monorepoDeps.shift());
           });
         });

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -43,8 +43,7 @@ function npmPackage(modulePath, cb) {
   npmLib.then(npm => {
     npm.commands.pack([], (err, result) => {
       if (err) return cb(err);
-      console.debug('# pack result', modulePath, JSON.stringify(result));
-      const name = result[0];
+      const name = result[0].filename;
       fs.stat(name, (err, stats) => {
         if (err) console.error('# npm pack failed to produce the result file', npm, process.cwd());
         cb(err, err ? undefined : name);

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('path');
 const fs = require('fs');
+const mnpm = require('./mnpm');
 
 const npmLib = new Promise((resolve,reject) => {
   // ls -la $(which npm), or we could do something like https://stackoverflow.com/a/25106648/113009
@@ -52,10 +53,6 @@ function npmPackage(modulePath, cb) {
   });
 }
 
-function stringifyPackageJson(package) {
-  return JSON.stringify(package, null, '  ');
-}
-
 let package = require(path.join(dir,'package.json'));
 let monorepoDeps = Object.keys(package.dependencies).filter(
   dep => /^file:\.\.\//.test(package.dependencies[dep]));
@@ -75,10 +72,10 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
   const completed = () => {
     process.chdir(dir); // restore after npm
     fs.unlink(path.join(cimdir, 'package.json'), err => err && console.error('Failed to clean up after sourceless tgz pack', err));
-    fs.writeFile(path.join(mdir, 'package.json'), stringifyPackageJson(package),
+    fs.writeFile(path.join(mdir, 'package.json'), mnpm.stringifyPackageJson(package),
       err => { if (err) throw err; });
     const ciPackage = getCiPackage(package);
-    fs.writeFile(path.join(cidir, 'package.json'), stringifyPackageJson(ciPackage),
+    fs.writeFile(path.join(cidir, 'package.json'), mnpm.stringifyPackageJson(ciPackage),
       err => { if (err) throw err; });
     fs.unlink(path.join(cimdir, '.npmignore'), err => err && console.error(err));
   };
@@ -107,7 +104,7 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
         let depCiPackage = getCiPackage(depPackage);
         // We could probably speed things up here by using tar-stream, and maybe set permissions
         let depPpJson = path.join(cimdir, 'package.json');
-        fs.writeFile(depPpJson, stringifyPackageJson(depCiPackage), err => {
+        fs.writeFile(depPpJson, mnpm.stringifyPackageJson(depCiPackage), err => {
           fs.chownSync(depPpJson, 1000, 1000);
           process.chdir(cimdir); // for npm
           npmPackage(cimdir, (err, tgzname) => {

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -106,9 +106,7 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
         package.dependencies[dep] = `file:npm-monorepo/${tgzname}`;
 
         let depCiPackage = getCiPackage(depPackage);
-        let depPpJson = path.join(cimdir, 'package.json');
-        fs.writeFile(depPpJson, stringifyPackageJson(depCiPackage), err => {
-          fs.utimesSync(depPpJson, 0, 0); // so we get consistent hashes for prod packages
+        fs.writeFile(path.join(cimdir, 'package.json'), stringifyPackageJson(depCiPackage), err => {
           process.chdir(cimdir); // for npm
           npmPackage(cimdir, (err, tgzname) => {
             console.log('# Created monorepo sourceless tarball for npm ci', cimdir, tgzname);

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -105,11 +105,13 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
         // We could probably speed things up here by using tar-stream, and maybe set permissions
         let depPpJson = path.join(cimdir, 'package.json');
         fs.writeFile(depPpJson, mnpm.stringifyPackageJson(depCiPackage), err => {
-          fs.chownSync(depPpJson, 1000, 1000);
-          process.chdir(cimdir); // for npm
-          npmPackage(cimdir, (err, tgzname) => {
+          mnpm.writeProdPackageTgzWithDeterministicHash({
+            packageJsonObject: getCiPackage(depPackage),
+            filePath: path.join(cimdir, tgzname)
+          }).then(() => {
             console.log('# Created monorepo sourceless tarball for npm ci', cimdir, tgzname);
             console.log('------- debug info -------');
+            process.chdir(cimdir); // for npm
             require('child_process').execSync('tar xvzf ' + tgzname, {stdio:[0,1,2]});
             require('child_process').execSync('ls -la package/', {stdio:[0,1,2]});
             require('child_process').execSync('shasum package/package.json', {stdio:[0,1,2]});

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -106,7 +106,9 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
         package.dependencies[dep] = `file:npm-monorepo/${tgzname}`;
 
         let depCiPackage = getCiPackage(depPackage);
-        fs.writeFile(path.join(cimdir, 'package.json'), stringifyPackageJson(depCiPackage), err => {
+        let depPpJson = path.join(cimdir, 'package.json');
+        fs.writeFile(depPpJson, stringifyPackageJson(depCiPackage), err => {
+          fs.utimesSync(depPpJson, 0, 0); // so we get consistent hashes for prod packages
           process.chdir(cimdir); // for npm
           npmPackage(cimdir, (err, tgzname) => {
             console.log('# Created monorepo sourceless tarball for npm ci', cimdir, tgzname);

--- a/nodejs/build-contract-predockerbuild
+++ b/nodejs/build-contract-predockerbuild
@@ -105,7 +105,10 @@ mk(dir, mk.bind(null, mdir, mk.bind(null, cidir, mk.bind(null, cimdir, err => {
         package.dependencies[dep] = `file:npm-monorepo/${tgzname}`;
 
         let depCiPackage = getCiPackage(depPackage);
-        fs.writeFile(path.join(cimdir, 'package.json'), stringifyPackageJson(depCiPackage), err => {
+        // We could probably speed things up here by using tar-stream, and maybe set permissions
+        let depPpJson = path.join(cimdir, 'package.json');
+        fs.writeFile(depPpJson, stringifyPackageJson(depCiPackage), err => {
+          fs.chownSync(depPpJson, 1000, 1000);
           process.chdir(cimdir); // for npm
           npmPackage(cimdir, (err, tgzname) => {
             console.log('# Created monorepo sourceless tarball for npm ci', cimdir, tgzname);

--- a/nodejs/mnpm.js
+++ b/nodejs/mnpm.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const tar = require('tar-stream');
+const zlib = require('zlib');
+
+const tarContentMtime = new Date(946681200000);
+
+function stringifyPackageJson(packageJsonObject) {
+  return JSON.stringify(packageJsonObject, null, '  ') + '\n';
+}
+
+async function writeProdPackageTgzWithDeterministicHash({packageJsonObject, filePath}) {
+  const content = stringifyPackageJson(packageJsonObject);
+  const pack = tar.pack();
+  const p = pack.entry({
+    name: 'package/package.json',
+    mtime: tarContentMtime
+  }, content);
+  const fileStream = fs.createWriteStream(filePath);
+  const completed = new Promise((resolve, reject) => {
+    fileStream.on('close', resolve);
+  });
+  pack.finalize();
+  pack
+    .pipe(zlib.createGzip())
+    .pipe(fileStream);
+  return completed;
+};
+
+module.exports = {
+  stringifyPackageJson,
+  writeProdPackageTgzWithDeterministicHash
+};

--- a/nodejs/mnpm.js
+++ b/nodejs/mnpm.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const tar = require('tar-stream');
 const zlib = require('zlib');
 
-const tarContentMtime = new Date(946681200000);
+const tarContentMtime = new Date(946684800000);
 
 function stringifyPackageJson(packageJsonObject) {
   return JSON.stringify(packageJsonObject, null, '  ') + '\n';

--- a/nodejs/mnpm.spec.js
+++ b/nodejs/mnpm.spec.js
@@ -26,8 +26,14 @@ describe("Our choice of gzip function", () => {
     result.on('data', d => sha256.update(d));
     result.on('end', () => expect(sha256.digest('hex')).toBe(
       'c5f9a2352dadba9488900ba6ede0133270e12350ffa6d6ebbdefef9ee6aa2238'));
+    // Note that this differs from `echo 'x' | gzip - | shasum -a 256 -`
     blob.pipe(zlib.createGzip()).pipe(result);
     blob.end('x\n');
+  });
+
+  // https://github.com/nodejs/node/issues/12244
+  it("Results may depend on zlib version", () => {
+    expect(process.versions.zlib).toBe('1.2.11');
   });
 
 });

--- a/nodejs/mnpm.spec.js
+++ b/nodejs/mnpm.spec.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const zlib = require('zlib');
+const stream = require('stream');
 const tar = require('tar-stream');
 
 const mnpm = require('./mnpm');
@@ -12,6 +13,21 @@ describe("stringifyPackageJson", () => {
   it("Uses two whitespaces to indent (the Yolean convention) and adds a trailing newline", () => {
     const string = mnpm.stringifyPackageJson({name: 'test-module'});
     expect(string).toBe('{\n  "name": "test-module"\n}\n');
+  });
+
+});
+
+describe("Our choice of gzip function", () => {
+
+  it("Is platform independent wrt result checksum", () => {
+    const blob = new stream.PassThrough();
+    const sha256 = crypto.createHash('sha256');
+    const result = new stream.PassThrough();
+    result.on('data', d => sha256.update(d));
+    result.on('end', () => expect(sha256.digest('hex')).toBe(
+      'c5f9a2352dadba9488900ba6ede0133270e12350ffa6d6ebbdefef9ee6aa2238'));
+    blob.pipe(zlib.createGzip()).pipe(result);
+    blob.end('x\n');
   });
 
 });

--- a/nodejs/mnpm.spec.js
+++ b/nodejs/mnpm.spec.js
@@ -1,0 +1,43 @@
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const mnpm = require('./mnpm');
+
+describe("stringifyPackageJson", () => {
+
+  it("Uses two whitespaces to indent (the Yolean convention) and adds a trailing newline", () => {
+    const string = mnpm.stringifyPackageJson({name: 'test-module'});
+    expect(string).toBe('{\n  "name": "test-module"\n}\n');
+  });
+
+});
+
+describe("writeProdPackageTgzWithDeterministicHash", () => {
+
+  it("Writes a file", async () => {
+    const filePath = path.join(os.tmpdir(), 'build-contract-test-mnpm-' + Date.now() + '.tgz');
+    await mnpm.writeProdPackageTgzWithDeterministicHash({
+      packageJsonObject: {
+        "dependencies": {
+          "build-contract": "1.5.0"
+        }
+      },
+      filePath
+    });
+    const stat = await fs.promises.stat(filePath);
+    // we base these assertions on a test result, not on npm pack output (which differs)
+    // and use the assertions to see if something changes over time or across platforms
+    expect(stat.size).toBe(154);
+    const tgz = await fs.promises.readFile(filePath);
+    const sha256 = crypto.createHash('sha256');
+    sha256.update(tgz);
+    expect(sha256.digest('hex')).toBe('f9153d2eb9f6c5fce542c07540c60d30f819f8886c300d6e39fa1c272e90a2c0');
+    const sha512 = crypto.createHash('sha512');
+    sha512.update(tgz);
+    expect(sha512.digest('base64')).toBe('PWPbKiNEVWpu+1gyqpvy0uYpGnq7tJUBq4OxFzllDI+3AgZJcivUcP5k5BIOBG7lIxI3WUkBNA8cAVg/KUU4uw==');
+    await fs.promises.unlink(filePath);
+  });
+
+});

--- a/nodejs/mnpm.spec.js
+++ b/nodejs/mnpm.spec.js
@@ -35,10 +35,10 @@ describe("writeProdPackageTgzWithDeterministicHash", () => {
     const tgz = await fs.promises.readFile(filePath);
     const sha256 = crypto.createHash('sha256');
     sha256.update(tgz);
-    expect(sha256.digest('hex')).toBe('f9153d2eb9f6c5fce542c07540c60d30f819f8886c300d6e39fa1c272e90a2c0');
+    expect(sha256.digest('hex')).toBe('3be69fccaf4716df00adee93c219cfe44f1425aa968d33b6a3a4e725192586be');
     const sha512 = crypto.createHash('sha512');
     sha512.update(tgz);
-    expect(sha512.digest('base64')).toBe('PWPbKiNEVWpu+1gyqpvy0uYpGnq7tJUBq4OxFzllDI+3AgZJcivUcP5k5BIOBG7lIxI3WUkBNA8cAVg/KUU4uw==');
+    expect(sha512.digest('base64')).toBe('M24fZ1mSsZYX8dSCGSd54842GgAKd80xInWqNUhSZH1/hx7syKOOx05qMhD8avcFdXNnDMG/N2i/YZJFJNW6rQ==');
     await fs.promises.unlink(filePath);
   });
 
@@ -69,6 +69,8 @@ describe("writeProdPackageTgzWithDeterministicHash", () => {
         expect(header.gname).toBe('');
         expect(header.devmajor).toBe(0);
         expect(header.devminor).toBe(0);
+        expect(header.mtime).toBeInstanceOf(Date);
+        expect(header.mtime.getTime()).toBe(946684800000);
         expect(Object.keys(header).length).toBe(12);
 
         stream.on('end', function() {

--- a/nodejs/zlib-choice.js
+++ b/nodejs/zlib-choice.js
@@ -1,0 +1,6 @@
+const zlib = require('zlib');
+const pakoStreams = require('browserify-zlib');
+
+module.exports.createGzip = pakoStreams.createGzip;
+module.exports.createGunzip = zlib.createGunzip;
+module.exports.constants = zlib.constants;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,13 @@
   },
   "homepage": "https://github.com/Yolean/build-contract#readme",
   "dependencies": {
+    "tar-stream": "1.6.1",
     "yamljs": "0.2.8"
   },
   "peerDependencies": {
     "npm": "5.8.0"
+  },
+  "devDependencies": {
+    "jest": "22.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,6 @@
   "name": "build-contract",
   "version": "1.4.0",
   "description": "Defines a successful build and test run for a microservice, from source to docker push",
-  "main": "build-contract",
-  "bin": {
-    "build-contract": "./build-contract",
-    "build-contract-predockerbuild": "./nodejs/build-contract-predockerbuild",
-    "build-contract-packagelock": "./nodejs/build-contract-packagelock"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Yolean/build-contract.git"
@@ -18,12 +12,25 @@
     "url": "https://github.com/Yolean/build-contract/issues"
   },
   "homepage": "https://github.com/Yolean/build-contract#readme",
+  "main": "build-contract",
+  "bin": {
+    "build-contract": "./build-contract",
+    "build-contract-predockerbuild": "./nodejs/build-contract-predockerbuild",
+    "build-contract-packagelock": "./nodejs/build-contract-packagelock"
+  },
+  "scripts": {
+    "unittest": "./node_modules/.bin/jest",
+    "build-contract-predockerbuild": "./nodejs/build-contract-predockerbuild"
+  },
+  "engines": {
+    "node": ">=10.1.0"
+  },
   "dependencies": {
     "tar-stream": "1.6.1",
     "yamljs": "0.2.8"
   },
   "peerDependencies": {
-    "npm": "5.8.0"
+    "npm": "6.0.1"
   },
   "devDependencies": {
     "jest": "22.4.4"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "build-contract": "./build-contract",
     "build-contract-predockerbuild": "./nodejs/build-contract-predockerbuild",
-    "packagelock": "./nodejs/build-contract-packagelock"
+    "build-contract-packagelock": "./nodejs/build-contract-packagelock"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
These hashes should be for a minimal tgz, with only a package.json containing `dependencies`. I think file timestamps was the issue, but we need to validate this for actual builds not only https://github.com/solsson/npm-monorepo-example