### PR TITLE
Set the -dev suffix on GIT_COMMIT less often

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -20,7 +20,7 @@ export BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null || echo '')
 if [[ ! -z "$GIT_COMMIT" ]]; then
-  GIT_STATUS=$(git status -s)
+  GIT_STATUS=$(git status --untracked-files=no --porcelain=v2)
   if [[ ! -z "$GIT_STATUS" ]]; then
     GIT_COMMIT="$GIT_COMMIT-dev"
   fi


### PR DESCRIPTION
I think this is the criteria that Skaffold uses, but note that there we get the full git sha and the suffix is `-dirty` instead of `-dev`.