### PR TITLE
Fixes for build contract when not running in our docker:dind image

### DIFF
--- a/build-contract
+++ b/build-contract
@@ -156,7 +156,7 @@ for compose_file in $(ls $CONTRACTS_DIR | grep .yml); do
   compose_name=${compose_name%%\.docker-compose}
   [[ ! -z "$PROJECT_NAME" ]] && compose_name="${PROJECT_NAME}_$compose_name"
   echo "  --- build-contract: $compose_name ($CONTRACTS_DIR$compose_file) ---  "
-  docker_compose="docker-compose --ansi=never --progress=plain -f $CONTRACTS_DIR$compose_file$BUILD_CONTRACT_EXTRA -p $compose_name"
+  docker_compose="docker compose --ansi=never --progress=plain -f $CONTRACTS_DIR$compose_file$BUILD_CONTRACT_EXTRA -p $compose_name"
   echo "  --- build-contract: $docker_compose ---  "
   if [[ "$BUILD_CONTRACT_DRYRUN" == true ]]; then
     docker_compose="echo $docker_compose"
@@ -192,7 +192,7 @@ for compose_file in $(ls "$CONTRACTS_DIR" | grep .yml); do
   fi
   echo "  --- build-contract: $compose_file ---  "
   compose_file="$CONTRACTS_DIR$compose_file"
-  docker_compose="docker-compose --ansi=never --progress=plain -f $compose_file$BUILD_CONTRACT_EXTRA"
+  docker_compose="docker compose --ansi=never --progress=plain -f $compose_file$BUILD_CONTRACT_EXTRA"
   if [[ "$BUILD_CONTRACT_DRYRUN" == true ]]; then
     docker_compose="echo $docker_compose"
   fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "browserify-zlib": "0.2.0",
-        "npm": "11.6.4",
+        "npm": "~6.14.18",
         "pako": "1.0.6",
         "tar-stream": "1.6.1",
         "yamljs": "0.2.8"
@@ -72,7 +72,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1318,7 +1317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -1457,7 +1455,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1671,7 +1668,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2174,7 +2170,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2325,7 +2320,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2425,7 +2419,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isarray": {
@@ -2438,7 +2431,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3321,7 +3313,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3481,159 +3472,266 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.6.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.6.4.tgz",
-      "integrity": "sha512-ERjKtGoFpQrua/9bG0+h3xiv/4nVdGViCjUYA1AmlV24fFvfnSB7B7dIfZnySQ1FDLd0ZVrWPsLLp78dCtJdRQ==",
+      "version": "6.14.18",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.18.tgz",
+      "integrity": "sha512-p3SjqSchSuNQUqbJBgwdv0L3O6bKkaSfQrQzJsskNpNKLg0g37c5xTXFV0SqTlX9GWvoGxBELVJMRWq0J8oaLA==",
       "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/config",
-        "@npmcli/fs",
-        "@npmcli/map-workspaces",
-        "@npmcli/metavuln-calculator",
-        "@npmcli/package-json",
-        "@npmcli/promise-spawn",
-        "@npmcli/redact",
-        "@npmcli/run-script",
-        "@sigstore/tuf",
         "abbrev",
+        "ansicolors",
+        "ansistyles",
+        "aproba",
         "archy",
+        "bin-links",
+        "bluebird",
+        "byte-size",
         "cacache",
-        "chalk",
+        "call-limit",
+        "chownr",
         "ci-info",
         "cli-columns",
-        "fastest-levenshtein",
-        "fs-minipass",
+        "cli-table3",
+        "cmd-shim",
+        "columnify",
+        "config-chain",
+        "debuglog",
+        "detect-indent",
+        "detect-newline",
+        "dezalgo",
+        "editor",
+        "figgy-pudding",
+        "find-npm-prefix",
+        "fs-vacuum",
+        "fs-write-stream-atomic",
+        "gentle-fs",
         "glob",
         "graceful-fs",
+        "has-unicode",
         "hosted-git-info",
+        "iferr",
+        "imurmurhash",
+        "infer-owner",
+        "inflight",
+        "inherits",
         "ini",
         "init-package-json",
         "is-cidr",
-        "json-parse-even-better-errors",
+        "json-parse-better-errors",
+        "JSONStream",
+        "lazy-property",
+        "libcipm",
+        "libnpm",
         "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
+        "libnpmhook",
         "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
         "libnpmsearch",
         "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minimatch",
-        "minipass",
-        "minipass-pipeline",
-        "ms",
+        "libnpx",
+        "lock-verify",
+        "lockfile",
+        "lodash._baseindexof",
+        "lodash._baseuniq",
+        "lodash._bindcallback",
+        "lodash._cacheindexof",
+        "lodash._createcache",
+        "lodash._getnative",
+        "lodash.clonedeep",
+        "lodash.restparam",
+        "lodash.union",
+        "lodash.uniq",
+        "lodash.without",
+        "lru-cache",
+        "meant",
+        "mississippi",
+        "mkdirp",
+        "move-concurrently",
         "node-gyp",
         "nopt",
+        "normalize-package-data",
         "npm-audit-report",
+        "npm-cache-filename",
         "npm-install-checks",
+        "npm-lifecycle",
         "npm-package-arg",
+        "npm-packlist",
         "npm-pick-manifest",
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "p-map",
+        "npmlog",
+        "once",
+        "opener",
+        "osenv",
         "pacote",
-        "parse-conflict-json",
-        "proc-log",
+        "path-is-inside",
+        "promise-inflight",
         "qrcode-terminal",
+        "query-string",
+        "qw",
+        "read-cmd-shim",
+        "read-installed",
+        "read-package-json",
+        "read-package-tree",
         "read",
+        "readable-stream",
+        "readdir-scoped-modules",
+        "request",
+        "retry",
+        "rimraf",
+        "safe-buffer",
         "semver",
-        "spdx-expression-parse",
+        "sha",
+        "slide",
+        "sorted-object",
+        "sorted-union-stream",
         "ssri",
-        "supports-color",
+        "stringify-package",
         "tar",
         "text-table",
         "tiny-relative-date",
-        "treeverse",
+        "uid-number",
+        "umask",
+        "unique-filename",
+        "unpipe",
+        "update-notifier",
+        "uuid",
+        "validate-npm-package-license",
         "validate-npm-package-name",
-        "which"
+        "which",
+        "worker-farm",
+        "write-file-atomic"
       ],
       "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.8",
-        "@npmcli/config": "^10.4.4",
-        "@npmcli/fs": "^5.0.0",
-        "@npmcli/map-workspaces": "^5.0.3",
-        "@npmcli/metavuln-calculator": "^9.0.3",
-        "@npmcli/package-json": "^7.0.4",
-        "@npmcli/promise-spawn": "^9.0.1",
-        "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.0",
-        "abbrev": "^4.0.0",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
-        "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
-        "cli-columns": "^4.0.0",
-        "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.3",
-        "glob": "^13.0.0",
-        "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
-        "ini": "^6.0.0",
-        "init-package-json": "^8.2.4",
-        "is-cidr": "^6.0.1",
-        "json-parse-even-better-errors": "^5.0.0",
-        "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.11",
-        "libnpmexec": "^10.1.10",
-        "libnpmfund": "^7.0.11",
-        "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.11",
-        "libnpmpublish": "^11.1.3",
-        "libnpmsearch": "^9.0.1",
-        "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.3",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.1",
-        "minipass-pipeline": "^1.2.4",
-        "ms": "^2.1.2",
-        "node-gyp": "^12.1.0",
-        "nopt": "^9.0.0",
-        "npm-audit-report": "^7.0.0",
-        "npm-install-checks": "^8.0.0",
-        "npm-package-arg": "^13.0.2",
-        "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
-        "npm-registry-fetch": "^19.1.1",
-        "npm-user-validate": "^4.0.0",
-        "p-map": "^7.0.4",
-        "pacote": "^21.0.4",
-        "parse-conflict-json": "^5.0.1",
-        "proc-log": "^6.1.0",
+        "bin-links": "^1.1.8",
+        "bluebird": "^3.7.2",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.4",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.13",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "^1.0.4",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.2",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.3.1",
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.10",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.9",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.8",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.1.1",
+        "json-parse-better-errors": "^1.0.2",
+        "JSONStream": "^1.3.5",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.8",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.4",
+        "lock-verify": "^2.2.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "^1.0.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.6",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.1.1",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.3",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.5",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.7",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.2",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.12",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "read": "^5.0.1",
-        "semver": "^7.7.3",
-        "spdx-expression-parse": "^4.0.0",
-        "ssri": "^13.0.0",
-        "supports-color": "^10.2.2",
-        "tar": "^7.5.2",
+        "query-string": "^6.14.1",
+        "qw": "^1.0.2",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.5",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.2",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.2",
+        "retry": "^0.12.0",
+        "rimraf": "^2.7.1",
+        "safe-buffer": "^5.2.1",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.2",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.19",
         "text-table": "~0.2.0",
-        "tiny-relative-date": "^2.0.2",
-        "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^7.0.0",
-        "which": "^6.0.0"
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.4.0",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "6 >=6.2.0 || 8 || >=9.3.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -3649,408 +3747,81 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
+    "node_modules/npm/node_modules/@iarna/cli": {
+      "version": "2.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^11.2.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.8",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^5.0.0",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/metavuln-calculator": "^9.0.2",
-        "@npmcli/name-from-folder": "^4.0.0",
-        "@npmcli/node-gyp": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/query": "^5.0.0",
-        "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "bin-links": "^6.0.0",
-        "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^9.0.0",
-        "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^11.2.1",
-        "minimatch": "^10.0.3",
-        "nopt": "^9.0.0",
-        "npm-install-checks": "^8.0.0",
-        "npm-package-arg": "^13.0.0",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-registry-fetch": "^19.0.0",
-        "pacote": "^21.0.2",
-        "parse-conflict-json": "^5.0.1",
-        "proc-log": "^6.0.0",
-        "proggy": "^4.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^3.0.1",
-        "semver": "^7.3.7",
-        "ssri": "^13.0.0",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "ci-info": "^4.0.0",
-        "ini": "^6.0.0",
-        "nopt": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "7.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^9.0.0",
-        "ini": "^6.0.0",
-        "lru-cache": "^11.2.1",
-        "npm-pick-manifest": "^11.0.1",
-        "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^5.0.0",
-        "npm-normalize-package-bin": "^5.0.0"
-      },
-      "bin": {
-        "installed-package-contents": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "5.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "glob": "^13.0.0",
-        "minimatch": "^10.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "9.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^20.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "pacote": "^21.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "7.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "glob": "^13.0.0",
-        "hosted-git-info": "^9.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "9.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0",
-        "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.5.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
-        "@sigstore/protobuf-specs": "^0.5.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "glob": "^7.1.2",
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "4.0.0",
+      "version": "1.1.1",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.4",
+      "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/agentkeepalive": {
+      "version": "3.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-align": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^2.0.0"
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
+      "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
+    "node_modules/npm/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ansistyles": {
+      "version": "0.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/aproba": {
-      "version": "2.1.0",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC"
     },
@@ -4059,182 +3830,772 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asn1": {
+      "version": "0.2.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/asynckit": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/aws4": {
+      "version": "1.11.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "1.1.8",
       "inBundle": true,
-      "license": "ISC",
+      "license": "Artistic-2.0",
       "dependencies": {
-        "cmd-shim": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "read-cmd-shim": "^6.0.0",
-        "write-file-atomic": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "bluebird": "^3.5.3",
+        "cmd-shim": "^3.0.0",
+        "gentle-fs": "^2.3.0",
+        "graceful-fs": "^4.1.15",
+        "npm-normalize-package-bin": "^1.0.0",
+        "write-file-atomic": "^2.3.0"
       }
     },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "3.1.0",
+    "node_modules/npm/node_modules/bluebird": {
+      "version": "3.7.2",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
-    "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+    "node_modules/npm/node_modules/boxen": {
+      "version": "1.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^5.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^13.0.0",
-        "lru-cache": "^11.1.0",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/chalk": {
-      "version": "5.6.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/chownr": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "5.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/cmd-shim": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cssesc": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/debug": {
-      "version": "4.4.3",
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+    "node_modules/npm/node_modules/buffer-from": {
+      "version": "1.0.0",
       "inBundle": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/builtins": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/byline": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm/node_modules/byte-size": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "12.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/call-limit": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/camelcase": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/capture-stack-trace": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/caseless": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "2.0.10",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-boxes": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3": {
+      "version": "0.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cliui": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-convert": {
+      "version": "1.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/color-name": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/colors": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/npm/node_modules/columnify": {
+      "version": "1.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/config-chain": {
+      "version": "1.1.13",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/npm/node_modules/configstore": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^4.2.1",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/create-error-class": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cyclist": {
+      "version": "0.2.2",
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/dashdash": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/decamelize": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/define-properties": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/detect-indent": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/detect-newline": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/dot-prop": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/dotenv": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexer3": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/npm/node_modules/duplexify": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/editor": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "version": "7.0.3",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
+      "version": "0.1.12",
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "iconv-lite": "^0.6.2"
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "node_modules/npm/node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -4246,116 +4607,654 @@
       }
     },
     "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
+      "version": "1.1.2",
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.3",
+    "node_modules/npm/node_modules/errno": {
+      "version": "0.1.7",
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "MIT",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
     },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
+    "node_modules/npm/node_modules/es-abstract": {
+      "version": "1.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es-to-primitive": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es6-promise": {
+      "version": "4.2.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 4.9.1"
+        "node": ">=0.8.0"
       }
     },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.3",
+    "node_modules/npm/node_modules/execa": {
+      "version": "0.7.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.3"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/glob": {
-      "version": "13.0.0",
+    "node_modules/npm/node_modules/execa/node_modules/get-stream": {
+      "version": "3.0.0",
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.11",
+    "node_modules/npm/node_modules/extend": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/figgy-pudding": {
+      "version": "3.5.2",
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+    "node_modules/npm/node_modules/filter-obj": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/find-npm-prefix": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/flush-write-stream": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/form-data": {
+      "version": "2.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/npm/node_modules/from2": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "1.2.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "minipass": "^2.6.0"
       }
     },
-    "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.2.0",
+    "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "2.9.0",
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
     },
-    "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
+    "node_modules/npm/node_modules/fs-vacuum": {
+      "version": "1.2.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
+      "version": "2.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
+      "version": "1.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
+        "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gauge": {
+      "version": "2.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/ignore-walk": {
-      "version": "8.0.0",
+    "node_modules/npm/node_modules/genfun": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gentle-fs": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "aproba": "^1.1.2",
+        "chownr": "^1.1.2",
+        "cmd-shim": "^3.0.3",
+        "fs-vacuum": "^1.2.10",
+        "graceful-fs": "^4.1.11",
+        "iferr": "^0.1.5",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^0.5.1",
+        "path-is-inside": "^1.0.2",
+        "read-cmd-shim": "^1.0.1",
+        "slide": "^1.1.6"
+      }
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/npm/node_modules/get-stream": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/getpass": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "7.2.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^10.0.3"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got": {
+      "version": "6.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got/node_modules/get-stream": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/har-schema": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator": {
+      "version": "5.1.5",
+      "deprecated": "this library is no longer supported",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/has-symbols": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "3.8.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/http-signature": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.4.23",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/iferr": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/import-lazy": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -4366,92 +5265,241 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/npm/node_modules/ini": {
-      "version": "6.0.0",
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/init-package-json": {
-      "version": "8.2.4",
+    "node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/package-json": "^7.0.0",
-        "npm-package-arg": "^13.0.0",
-        "promzard": "^3.0.1",
-        "read": "^5.0.1",
-        "semver": "^7.7.2",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
-    "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+    "node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "1.3.8",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "1 || 2",
+        "semver": "2.x || 3.x || 4 || 5",
+        "validate-npm-package-license": "^3.0.1",
+        "validate-npm-package-name": "^3.0.0"
       }
+    },
+    "node_modules/npm/node_modules/ip": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
+      "version": "2.1.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
+    "node_modules/npm/node_modules/is-callable": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^1.5.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^2.0.10"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/is-date-object": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-installed-globally": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-npm": {
+      "version": "1.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm/node_modules/is-obj": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-path-inside": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-redirect": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-regex": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-stream": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-symbol": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
-      "version": "3.1.1",
+      "version": "2.0.0",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/isstream": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "5.0.0",
+      "version": "2.3.1",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
+      "license": "MIT"
     },
-    "node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
+    "node_modules/npm/node_modules/json-schema": {
+      "version": "0.4.0",
       "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/npm/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
@@ -4461,624 +5509,1071 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/just-diff": {
-      "version": "6.0.2",
+    "node_modules/npm/node_modules/JSONStream": {
+      "version": "1.3.5",
       "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.5.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "10.0.3",
-      "inBundle": true,
-      "license": "ISC",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "npm-package-arg": "^13.0.0",
-        "npm-registry-fetch": "^19.0.0"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "*"
       }
     },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.11",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.1.8",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "binary-extensions": "^3.0.0",
-        "diff": "^8.0.2",
-        "minimatch": "^10.0.3",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2",
-        "tar": "^7.5.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.10",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.1.8",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2",
-        "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "read": "^5.0.1",
-        "semver": "^7.3.7",
-        "signal-exit": "^4.1.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.11",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.1.8"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "8.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.11",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.1.8",
-        "@npmcli/run-script": "^10.0.0",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/package-json": "^7.0.0",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^13.0.0",
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.7",
-        "sigstore": "^4.0.0",
-        "ssri": "^13.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "9.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmteam": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^4.0.0",
-        "cacache": "^20.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^5.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^13.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch": {
-      "version": "10.1.1",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/jsprim": {
+      "version": "1.4.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^3.0.1"
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "node": ">=0.6.0"
       }
     },
-    "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib": {
+    "node_modules/npm/node_modules/latest-version": {
       "version": "3.1.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.1.2"
+        "package-json": "^4.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
+    "node_modules/npm/node_modules/lazy-property": {
+      "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/mute-stream": {
-      "version": "3.0.0",
+    "node_modules/npm/node_modules/libcipm": {
+      "version": "4.0.8",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "graceful-fs": "^4.1.11",
+        "ini": "^1.3.5",
+        "lock-verify": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "pacote": "^9.1.0",
+        "read-package-json": "^2.0.13",
+        "rimraf": "^2.6.2",
+        "worker-farm": "^1.6.0"
       }
     },
-    "node_modules/npm/node_modules/negotiator": {
-      "version": "1.0.0",
+    "node_modules/npm/node_modules/libnpm": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "find-npm-prefix": "^1.0.2",
+        "libnpmaccess": "^3.0.2",
+        "libnpmconfig": "^1.2.1",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmpublish": "^1.1.2",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "lock-verify": "^2.0.2",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.0",
+        "npmlog": "^4.1.2",
+        "pacote": "^9.5.3",
+        "read-package-json": "^2.0.13",
+        "stringify-package": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpx": {
+      "version": "10.2.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^5.0.1",
+        "npm-package-arg": "^6.0.0",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.0",
+        "update-notifier": "^2.3.0",
+        "which": "^1.3.0",
+        "y18n": "^4.0.0",
+        "yargs": "^14.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/lock-verify": {
+      "version": "2.2.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@iarna/cli": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "semver": "^5.4.1"
+      },
+      "bin": {
+        "lock-verify": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/lockfile": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._baseindexof": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._bindcallback": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._cacheindexof": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._createcache": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._root": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.restparam": {
+      "version": "3.6.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.without": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/make-dir": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^12.0.0",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/meant": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mime-db": {
+      "version": "1.35.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.1.0",
+    "node_modules/npm/node_modules/mime-types": {
+      "version": "2.1.19",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
-        "nopt": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "tar": "^7.5.2",
-        "tinyglobby": "^0.2.12",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
+        "mime-db": "~1.35.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">= 0.6"
       }
     },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "9.0.0",
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^4.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "*"
       }
     },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "7.0.0",
+    "node_modules/npm/node_modules/minimist": {
+      "version": "1.2.6",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^2.9.0"
       }
     },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+      "version": "2.9.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "8.0.0",
+    "node_modules/npm/node_modules/mississippi": {
+      "version": "3.0.0",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "semver": "^7.1.1"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=4.0.0"
       }
     },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "13.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^8.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "11.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "npm-package-arg": "^13.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "19.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/redact": "^4.0.0",
-        "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^15.0.0",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^5.0.0",
-        "minizlib": "^3.0.1",
-        "npm-package-arg": "^13.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.4",
+    "node_modules/npm/node_modules/mkdirp": {
+      "version": "0.5.6",
       "inBundle": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.4",
-      "inBundle": true,
-      "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "cacache": "^20.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^13.0.0",
-        "npm-packlist": "^10.0.1",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^4.0.0",
-        "ssri": "^13.0.0",
-        "tar": "^7.4.3"
+        "minimist": "^1.2.6"
       },
       "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "5.0.1",
+    "node_modules/npm/node_modules/move-concurrently": {
+      "version": "1.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^5.0.0",
-        "just-diff": "^6.0.0",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
-    "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-fetch-npm": {
+      "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
       },
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/proc-log": {
-      "version": "6.1.0",
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "5.1.1",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.7.1",
+        "tar": "^4.4.12",
+        "which": "^1.3.1"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">= 6.0.0"
       }
     },
-    "node_modules/npm/node_modules/proggy": {
-      "version": "4.0.0",
+    "node_modules/npm/node_modules/nopt": {
+      "version": "4.0.3",
       "inBundle": true,
       "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
       }
     },
-    "node_modules/npm/node_modules/promise-all-reject-late": {
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cli-table3": "^0.5.0",
+        "console-control-strings": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-cache-filename": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^2.3.0 || 3.x || 4 || 5"
+      }
+    },
+    "node_modules/npm/node_modules/npm-lifecycle": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "byline": "^5.0.0",
+        "graceful-fs": "^4.1.15",
+        "node-gyp": "^5.0.2",
+        "resolve-from": "^4.0.0",
+        "slide": "^1.1.6",
+        "uid-number": "0.0.6",
+        "umask": "^1.1.0",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-logical-tree": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
       "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "6.1.1",
+      "inBundle": true,
       "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "dependencies": {
+        "hosted-git-info": "^2.7.1",
+        "osenv": "^0.1.5",
+        "semver": "^5.6.0",
+        "validate-npm-package-name": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/promise-call-limit": {
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "1.4.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "3.0.2",
       "inBundle": true,
       "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
       }
     },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.2 || 2",
+        "figgy-pudding": "^3.4.1",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "4.0.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "JSONStream": "^1.3.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "npm-package-arg": "^6.1.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/object-assign": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/object-keys": {
+      "version": "1.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/osenv": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/p-finally": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/package-json": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "9.5.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "cacache": "^12.0.2",
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-normalize-package-bin": "^1.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^3.0.0",
+        "npm-registry-fetch": "^4.0.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.10",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pacote/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/path-exists": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/path-key": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-parse": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/performance-now": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pify": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/promise-retry": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/npm/node_modules/proto-list": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/protoduck": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "genfun": "^5.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/prr": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pseudomap": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/psl": {
+      "version": "1.9.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pump": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify": {
+      "version": "1.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/promzard": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -5088,23 +6583,200 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/npm/node_modules/qs": {
+      "version": "6.5.3",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/npm/node_modules/query-string": {
+      "version": "6.14.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/qw": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/rc": {
+      "version": "1.2.8",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/npm/node_modules/read": {
-      "version": "5.0.1",
+      "version": "1.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "^3.0.0"
+        "mute-stream": "~0.0.4"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=0.8"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "6.0.0",
+      "version": "1.0.5",
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-installed": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-tree": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "util-promisify": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/registry-auth-token": {
+      "version": "3.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/registry-url": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/request": {
+      "version": "2.88.2",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/require-directory": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -5115,52 +6787,120 @@
         "node": ">= 4"
       }
     },
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "2.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "5.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm/node_modules/semver-diff": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/sha": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT)",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.1.0",
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/slide": {
+      "version": "1.1.6",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "*"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
+      "version": "4.1.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5169,33 +6909,87 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.3.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
       },
       "engines": {
-        "node": ">= 10.0.0",
+        "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
+      "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
+    "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-object": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "from2": "^1.3.0",
+        "stream-iterate": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
+      "version": "3.0.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5203,22 +6997,13 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
+      "version": "2.1.0",
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
+      "version": "3.0.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5227,77 +7012,267 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.5",
       "inBundle": true,
       "license": "CC0-1.0"
     },
+    "node_modules/npm/node_modules/split-on-first": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/sshpk": {
+      "version": "1.17.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm/node_modules/ssri": {
-      "version": "13.0.0",
+      "version": "6.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "figgy-pudding": "^3.5.1"
       }
+    },
+    "node_modules/npm/node_modules/stream-each": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/stream-shift": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
+      "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/stringify-package": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-eof": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "10.2.2",
+      "version": "5.4.0",
       "inBundle": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "has-flag": "^3.0.0"
       },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.2",
+      "version": "4.4.19",
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=4.5"
       }
     },
-    "node_modules/npm/node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/tar/node_modules/minipass": {
+      "version": "2.9.0",
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tar/node_modules/yallist": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/term-size": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^0.7.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=4"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -5305,101 +7280,235 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "2.0.2",
+    "node_modules/npm/node_modules/through": {
+      "version": "2.3.8",
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+    "node_modules/npm/node_modules/through2": {
+      "version": "2.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/timed-out": {
+      "version": "4.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/tough-cookie/node_modules/punycode": {
+      "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=6"
       }
     },
-    "node_modules/npm/node_modules/treeverse": {
-      "version": "3.0.0",
+    "node_modules/npm/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "inBundle": true,
+      "license": "Unlicense"
+    },
+    "node_modules/npm/node_modules/typedarray": {
+      "version": "0.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/uid-number": {
+      "version": "0.0.6",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "*"
       }
     },
-    "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+    "node_modules/npm/node_modules/umask": {
+      "version": "1.1.0",
       "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
+      "version": "1.1.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/npm/node_modules/unique-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/unpipe": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/unzip-response": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/update-notifier": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-extend": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-promisify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/uuid": {
+      "version": "3.4.0",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -5410,61 +7519,315 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/verror": {
+      "version": "1.10.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
+    "node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/walk-up-path": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "6.0.0",
+      "version": "1.3.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "which": "bin/which"
       }
     },
-    "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.0",
+    "node_modules/npm/node_modules/which-module": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "string-width": "^1.0.2"
       }
     },
-    "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+    "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/widest-line": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/worker-farm": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "errno": "~0.1.7"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/xtend": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/npm/node_modules/y18n": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yargs": {
+      "version": "14.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser": {
+      "version": "15.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.19",
@@ -5830,7 +8193,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -5886,7 +8248,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5919,7 +8280,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -6255,7 +8615,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
@@ -6431,7 +8790,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6471,7 +8829,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -6539,7 +8896,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yamljs": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "browserify-zlib": "0.2.0",
-    "npm": "11.6.4",
+    "npm": "~6.14.18",
     "pako": "1.0.6",
     "tar-stream": "1.6.1",
     "yamljs": "0.2.8"


### PR DESCRIPTION
I had accidentally accepted an npm lib upgrade through https://github.com/Yolean/build-contract/pull/63 which breaks our API use. Also new docker CE installs (on Ubuntu for example) don't have the docker-compose CLI.
